### PR TITLE
Enh: Create True Template Modules

### DIFF
--- a/gii/generators/ModuleGenerator.php
+++ b/gii/generators/ModuleGenerator.php
@@ -18,8 +18,8 @@ use yii\helpers\Url;
  */
 class ModuleGenerator extends \yii\gii\Generator
 {
-    public $namespace = "myCompany\\";
-    public $moduleID = "example";
+    public $namespace = 'humhub\\';
+    public $moduleID = 'example';
 
     public $icon;
 
@@ -91,7 +91,7 @@ class ModuleGenerator extends \yii\gii\Generator
                 ['namespace'],
                 'match',
                 'pattern' => '/^[a-zA-Z0-9\\\]+\\\$/',
-                'message' => Yii::t('DevtoolsModule.generators_ModuleGenerator', 'Only letters, numbers and backslashes are allowed, the namespace has to end with a backslash. e.g. \'myCompany\\\' or \'myCompany\\social\\\'.')
+                'message' => Yii::t('DevtoolsModule.generators_ModuleGenerator', 'The namespace is preset to \'humhub\\\' so that your module will work out of the box.')
             ],
             [
                 ['outputPath'],
@@ -128,7 +128,7 @@ class ModuleGenerator extends \yii\gii\Generator
         return [
             'moduleID' =>  Yii::t('DevtoolsModule.generators_ModuleGenerator', 'This refers to the ID of the module, e.g. <code>myApp</code>. The id is used within your class namespaces as well as the Module configuration.'),
             'outputPath' =>  Yii::t('DevtoolsModule.generators_ModuleGenerator', 'The temporary location of the generated files.'),
-            'namespace' => Yii::t('DevtoolsModule.generators_ModuleGenerator', 'The namespace prefix is used for all your module classes e.g., <code>myCompany</code> or <code>myCompany\\intranet</code>.'),
+            'namespace' => Yii::t('DevtoolsModule.generators_ModuleGenerator', 'The namespace prefix is used for all your module classes e.g., <code>humhub\\modules\\intranet</code>.'),
             'isUserModule' => Yii::t('DevtoolsModule.generators_ModuleGenerator', 'This module should be installable on a user profile.'),
             'isSpaceModule' => Yii::t('DevtoolsModule.generators_ModuleGenerator', 'This module should be installable on space level.'),
             'contentContainerName' => Yii::t('DevtoolsModule.generators_ModuleGenerator', 'This name will be shown in the module overview of Spaces and User Profiles'),
@@ -260,7 +260,7 @@ class ModuleGenerator extends \yii\gii\Generator
      */
     public function getClassNamespace($suffix = null)
     {
-        $namespace = $this->namespace . 'humhub\\modules\\' . $this->moduleID;
+        $namespace = $this->namespace . 'modules\\' . $this->moduleID;
         return ($suffix) ? $namespace . '\\' . $suffix : $namespace;
     }
 

--- a/gii/views/module/form.php
+++ b/gii/views/module/form.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @link https://www.humhub.org/
  * @copyright Copyright (c) 2017 HumHub GmbH & Co. KG
@@ -17,7 +18,8 @@ use humhub\modules\devtools\widgets\IconSelect;
 <?php \humhub\modules\devtools\assets\GiiAsset::register($this) ?>
 
 <div class="module-form">
-    <?= $form->field($generator, 'namespace'); ?>
+
+    <?= $form->field($generator, 'namespace')->textInput(['class' => 'form-control class-content-namespace', 'placeholder' => 'Namespace', 'disabled' => true]); ?>
     <?= $form->field($generator, 'moduleID'); ?>
 
     <div class="alert alert-warning">
@@ -55,7 +57,6 @@ use humhub\modules\devtools\widgets\IconSelect;
             $(showClass).show();
         }
     };
-
 
     displayIf('.isContainerModule', '.ifCotnainerModule');
     displayIf('.isAddContainerPermission', '.ifAddContainerPermission');


### PR DESCRIPTION
This fixes a few issues when generating a module;

- [x] Fix: generated namespace issues
- [x] Enh: Disable namespace textarea

Never allow users to add anything before `humhub\modules` or an error will happen, so this P/R not only removes this possibility but it also disables the textarea just in case someone tries adding one anyways. :smile: